### PR TITLE
Fix visualization of instanced object

### DIFF
--- a/pxr/imaging/plugin/hdRpr/instancer.cpp
+++ b/pxr/imaging/plugin/hdRpr/instancer.cpp
@@ -204,7 +204,7 @@ HdTimeSampleArray<VtMatrix4dArray, 2> HdRprInstancer::SampleInstanceTransforms(S
         auto& transforms = sa.values[i];
         transforms = VtMatrix4dArray(instanceIndices.size(), xf);
 
-        if (translates.count > 0 && translates.values[0].IsArrayValued()) {
+        if (!translates.values.empty() && translates.values[0].IsArrayValued()) {
             auto& type = translates.values[0].GetElementTypeid();
             if (type == typeid(GfVec3f)) {
                 ApplyTransform<TranslateOp, GfVec3f>(translates, instanceIndices, t, transforms.data());
@@ -215,7 +215,7 @@ HdTimeSampleArray<VtMatrix4dArray, 2> HdRprInstancer::SampleInstanceTransforms(S
             }
         }
 
-        if (rotates.count > 0 && rotates.values[0].IsArrayValued()) {
+        if (!rotates.values.empty() && rotates.values[0].IsArrayValued()) {
             auto& type = rotates.values[0].GetElementTypeid();
             if (type == typeid(GfQuath)) {
                 ApplyTransform<RotateOp, GfQuath>(rotates, instanceIndices, t, transforms.data());
@@ -226,7 +226,7 @@ HdTimeSampleArray<VtMatrix4dArray, 2> HdRprInstancer::SampleInstanceTransforms(S
             }
         }
 
-        if (scales.count > 0 && scales.values[0].IsArrayValued()) {
+        if (!scales.values.empty() && scales.values[0].IsArrayValued()) {
             auto& type = scales.values[0].GetElementTypeid();
             if (type == typeid(GfVec3f)) {
                 ApplyTransform<ScaleOp, GfVec3f>(scales, instanceIndices, t, transforms.data());
@@ -237,7 +237,7 @@ HdTimeSampleArray<VtMatrix4dArray, 2> HdRprInstancer::SampleInstanceTransforms(S
             }
         }
 
-        if (instanceXforms.count > 0 && instanceXforms.values[0].IsArrayValued()) {
+        if (!instanceXforms.values.empty() && instanceXforms.values[0].IsArrayValued()) {
             auto& type = instanceXforms.values[0].GetElementTypeid();
             if (type == typeid(GfMatrix4d)) {
                 ApplyTransform<TransformOp, GfMatrix4d>(instanceXforms, instanceIndices, t, transforms.data());


### PR DESCRIPTION
All instanced objects are placed to the center of the scene in RenderStudio. The PR fixes this problem.

The root of the problem is in HdSceneIndexAdapterSceneDelegate::_SamplePrimvar
If the number of instances is not specified, the number of times is zero. It is set to the authoredSamples which is returned from the function in the end, yet, before that the times array is resized with one valid value so the returned authoredSamples doesn't reflect the actual size of the array.
In HdSceneDelegate::SamplePrimvar the array size is ignored and the returned authoredSamples is set to the HdTimeSampleArray::count field.
To avoid such inconsistency in future, the fields: "count", "times" and "values" can be replaced with a single array of type
 > TfSmallVector<std::pair<TYPE, float>, CAPACITY>

In the current fix the count field is ignored and the actual array size is used instead.